### PR TITLE
Add an option to specify a geckodriver executable path for Selenium

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Or, display your entire local database organized by popularity:
 * `--format 'FORMAT'` (`-f 'FORMAT'`) can be used to specify the desired download format. You must write your selected format as follows (pick one): `'mp3-v0'`, `'mp3-320'`, `'flac'`, `'aac-hi'`, `'vorbis'`, `'alac'`, `'wav'`, `'aiff-lossless'`. If this is not supplied, **bcdl** will simply prompt to select a format while running.
 * `--directory 'DIRECTORY'` (`-d 'DIRECTORY'`) can be used to change the directory that music is *unzipped* and organized into. The default behavior is to organize into `./downloads/Artist/Album/`, alongside the .zip archives, which may be ideal for picard users. However, if you store your music in `/mnt/media/Music`, for example, you could pass `-d '/mnt/media/Music'`
 * `--dl-directory 'DIRECTORY'` (or `-dl 'DIRECTORY'`) can be used to specify where you'd like the .zip file(s) to download.
+* `--geckodriver-executable 'PATH/TO/EXECUTABLE'` (or `-g 'PATH/TO/EXECUTABLE'`) can be used to specify a geckodriver path if Selenium reports system problems such as 'binary is not a Firefox executable'. On most systems this is not required, but some operating systems such as newer versions of Ubuntu require the path `/snap/bin/geckodriver`.
 * `--keep` or `-k` to keep the downloaded zip archive after extracting it.
 
 ## Misc. notes

--- a/bcdl.py
+++ b/bcdl.py
@@ -32,7 +32,7 @@ def main():
     shared_db_con = init_db_con(GLOBALS)
 
     if GLOBALS['update']:
-        shared_driver = init_driver()
+        shared_driver = init_driver(GLOBALS)
         total_added_to_db = refresh_db(shared_driver, GLOBALS, shared_db_con)
         if (total_added_to_db == -1):
             print("Unable to update database! Exiting...")
@@ -59,7 +59,7 @@ def main():
                 selected_list.append(download_list[i])
 
         select_format(GLOBALS)
-        shared_driver = init_driver()
+        shared_driver = init_driver(GLOBALS)
         download_albums(selected_list, shared_driver, GLOBALS)
 
     if (GLOBALS['update']):
@@ -119,6 +119,8 @@ def set_global_vars():
                         help="Directory to place downloaded zip files")
     parser.add_argument("--directory", "-d", dest="directory", type=str, default=downloads_path,
                         help="Music directory to extract into")
+    parser.add_argument("--geckodriver-executable", "-g", dest="geckodriver_executable", type=str, default=None,
+                        help="Location for geckodriver binary if Selenium reports 'binary is not a firefox executable'")
     parser.add_argument("--keep", "-k", dest="keep", action="store_true", default=False,
                         help="Keep downloaded zip archives.")
 
@@ -143,6 +145,7 @@ def set_global_vars():
     GLOBALS['format'] = args.format
     GLOBALS['directory'] = args.directory
     GLOBALS['dl_directory'] = args.dl_directory
+    GLOBALS['geckodriver_executable'] = args.geckodriver_executable
 
     if (GLOBALS['update'] == False) and GLOBALS['search'] == None:
         print("--update, --search, or --non-english-search required; exiting")
@@ -151,8 +154,12 @@ def set_global_vars():
     return GLOBALS
 
 
-def init_driver():
-    shared_driver = webdriver.Firefox()
+def init_driver(GLOBALS):
+    if GLOBALS['geckodriver_executable'] == None:
+        shared_driver = webdriver.Firefox()
+    else:
+        driver_service = webdriver.FirefoxService(executable_path=GLOBALS['geckodriver_executable'])
+        shared_driver = webdriver.Firefox(service=driver_service)
     return shared_driver
 
 


### PR DESCRIPTION
This closes #1 by adding a new option `--geckodriver-executable` (or `-g`), which allows the user to specify a path if faced with a Selenium error message such as "binary is not a Firefox executable" (see more on [this StackOverflow post](https://stackoverflow.com/questions/76846675/selenium-ubuntu22-bug-message-binary-is-not-a-firefox-executable)). This occurs on some mainstream distros such as Ubuntu 22 and newer because Firefox and geckodriver both install into the `/snap/bin` directory.

The backwards compatibility is maintained when the `--geckodriver-executable` (or `-g`) option is not specified, as it defaults to `None` and the original code branch is executed. However, the `init_driver` function now requires the `GLOBALS` object as an argument, so the internal function signature has been modified.

This also updates the README to document the new option.